### PR TITLE
Make generic "Actor" class

### DIFF
--- a/src/classes/Actor.lua
+++ b/src/classes/Actor.lua
@@ -1,3 +1,10 @@
+--[
+--The Actor class, pertaining to any moveable, collidable object in-game
+--Can essentially be the base class for any collision-based object in the future
+--
+--TODO: Collision handling
+--]
+
 require "classes/Vector"
 require "classes/inherit"
 

--- a/src/classes/Actor.lua
+++ b/src/classes/Actor.lua
@@ -1,6 +1,5 @@
 require "classes/Vector"
 require "classes/inherit"
-require "utils"
 
 -- ** Class definition **
 
@@ -18,7 +17,6 @@ end
 
   -- Move based on the actor's current velocity and speed
 function Actor:move(dt)
-  utils.pprint(self)
   self.x = self.x + self.velocity.x * self.speed * dt
   self.y = self.y + self.velocity.y * self.speed * dt
 end

--- a/src/classes/Actor.lua
+++ b/src/classes/Actor.lua
@@ -1,0 +1,62 @@
+require "classes/Vector"
+require "classes/inherit"
+require "utils"
+
+-- ** Class definition **
+
+Actor = inherit.from(nil)
+
+function Actor:draw()
+  -- TODO: make color configurable
+  love.graphics.setColor(.8, .2, .2)
+  love.graphics.rectangle('fill',
+                          self:getDrawableX(),
+                          self:getDrawableY(),
+                          self.width,
+                          self.height)
+end
+
+  -- Move based on the actor's current velocity and speed
+function Actor:move(dt)
+  utils.pprint(self)
+  self.x = self.x + self.velocity.x * self.speed * dt
+  self.y = self.y + self.velocity.y * self.speed * dt
+end
+
+--[[
+  Actor XY coordinates based at the center of the player's feet, for
+  (hopefully) easier calculations
+
+  e.g.
+  _____
+  |   |
+  |   |
+  --X--
+
+  These methods convert back to corner mode for use in drawing
+--]]
+function Actor:getCornerX() return self.x - self.width/2 end
+function Actor:getCornerY() return self.y - self.height end
+
+-- Utilize camera offset to get the drawable X and Y
+function Actor:getDrawableX()
+  return self:getCornerX()
+end
+function Actor:getDrawableY()
+  return self:getCornerY()
+end
+
+function Actor:new(arg)
+  arg = arg or {}
+
+  local instance = {
+    x = arg.x or 0,
+    y = arg.y or 0,
+    width = CONFIG.unitSize,
+    height = CONFIG.unitSize * 2,
+    speed = CONFIG.unitSize * 4, -- Units/sec
+    velocity = Vector:new()
+  }
+
+  return self:create(instance)
+end

--- a/src/classes/Actor.lua
+++ b/src/classes/Actor.lua
@@ -7,7 +7,7 @@ Actor = inherit.from(nil)
 
 function Actor:draw()
   -- TODO: make color configurable
-  love.graphics.setColor(.8, .2, .2)
+  love.graphics.setColor(unpack(self.color))
   love.graphics.rectangle('fill',
                           self:getDrawableX(),
                           self:getDrawableY(),
@@ -50,10 +50,11 @@ function Actor:new(arg)
   local instance = {
     x = arg.x or 0,
     y = arg.y or 0,
-    width = CONFIG.unitSize,
-    height = CONFIG.unitSize * 2,
-    speed = CONFIG.unitSize * 4, -- Units/sec
-    velocity = Vector:new()
+    color = arg.color or { .4, .4, 1 },
+    width = arg.width or CONFIG.unitSize,
+    height = arg.height or CONFIG.unitSize * 2,
+    speed = arg.speed or CONFIG.unitSize * 4, -- Units/sec
+    velocity = Vector:new(),
   }
 
   return self:create(instance)

--- a/src/classes/Player.lua
+++ b/src/classes/Player.lua
@@ -3,8 +3,6 @@ require "classes/Vector"
 require "classes/inherit"
 require "classes/Actor"
 
-require "utils"
-
 -- ** Class definition **
 
 Player = inherit.from(Actor)

--- a/src/classes/Player.lua
+++ b/src/classes/Player.lua
@@ -1,3 +1,10 @@
+--[
+--An Actor specifically for the player-controlled character
+--Acts as any other actor but additionally captures keyboard inputs
+--
+--TODO: Could probably be made static?
+--TODO: Generalize player keys in an easily configurable way
+--]
 
 require "classes/Vector"
 require "classes/inherit"
@@ -10,7 +17,6 @@ Player = inherit.from(Actor)
 function Player:move(dt)
   self.velocity:reset()
 
-  -- TODO: Generalize player keys in a configurable way
   if (love.keyboard.isDown('left')) then
     self.velocity.x = self.velocity.x - 1
   end

--- a/src/classes/Player.lua
+++ b/src/classes/Player.lua
@@ -31,6 +31,15 @@ function Player:move(dt)
 end
 
 function Player:new(arg)
-  parentInstance = self.super:new(arg)
+  arg = arg or {}
+
+  local instance = {
+    color = arg.color or { .8, .2, .2 },
+    width = arg.width or CONFIG.unitSize,
+    height = arg.height or CONFIG.unitSize * 2,
+    speed = arg.speed or CONFIG.unitSize * 4, -- Units/sec
+  }
+
+  parentInstance = self.super:new(instance)
   return setmetatable(parentInstance, { __index = self })
 end

--- a/src/classes/Player.lua
+++ b/src/classes/Player.lua
@@ -1,19 +1,13 @@
 
 require "classes/Vector"
-require "classes/static/Camera"
+require "classes/inherit"
+require "classes/Actor"
+
+require "utils"
 
 -- ** Class definition **
 
-Player = {}
-
-function Player:draw()
-  love.graphics.setColor(.8, .2, .2)
-  love.graphics.rectangle('fill',
-                          self:getDrawableX(),
-                          self:getDrawableY(),
-                          self.width,
-                          self.height)
-end
+Player = inherit.from(Actor)
 
 function Player:move(dt)
   self.velocity:reset()
@@ -35,44 +29,10 @@ function Player:move(dt)
 
   self.velocity:normalize()
 
-  self.x = self.x + self.velocity.x * self.speed * dt
-  self.y = self.y + self.velocity.y * self.speed * dt
-end
-
---[[
-  Player XY coordinates based at the center of the player's feet, for
-  (hopefully) easier calculations
-
-  e.g.
-  _____
-  |   |
-  |   |
-  --X--
-
-  These methods convert back to corner mode for use in drawing
---]]
-function Player:getCornerX() return self.x - self.width/2 end
-function Player:getCornerY() return self.y - self.height end
-
--- Utilize camera offset to get the drawable X and Y
-function Player:getDrawableX()
-  return self:getCornerX()
-end
-function Player:getDrawableY()
-  return self:getCornerY()
+  self.super.move(self, dt)
 end
 
 function Player:new(arg)
-  arg = arg or {}
-
-  local p = {
-    x = arg.x or 0,
-    y = arg.y or 0,
-    width = CONFIG.unitSize,
-    height = CONFIG.unitSize * 2,
-    speed = CONFIG.unitSize * 4, -- Units/sec
-    velocity = Vector:new()
-  }
-
-  return setmetatable(p, { __index = self })
+  parentInstance = self.super:new(arg)
+  return setmetatable(parentInstance, { __index = self })
 end

--- a/src/classes/inherit.lua
+++ b/src/classes/inherit.lua
@@ -1,0 +1,30 @@
+--[[
+--Any and all general inheritance-related methods
+--Great help from:
+--http://lua-users.org/wiki/InheritanceTutorial
+--]]
+
+function _inheritFrom (baseClass)
+  -- Initialize new class with central meta table
+  local newClass = { super=baseClass }
+  local classMt = { __index = newClass }
+
+  -- Create generic creation method
+  function newClass:create(obj)
+    local instance = obj or {}
+    setmetatable(instance, classMt)
+    return instance
+  end
+
+  -- Perform inheritance
+  if baseClass ~= nil then
+    setmetatable(newClass, { __index = baseClass })
+  end
+
+  return newClass
+end
+
+-- Export in traceable way
+inherit = {
+  from = _inheritFrom
+}

--- a/src/main.lua
+++ b/src/main.lua
@@ -1,5 +1,4 @@
 require "classes/Player"
-require "utils"
 require "classes/static/Camera"
 
 -- ** Global Definitions **
@@ -10,6 +9,8 @@ CONFIG = {
   windowUnitHeight = 8, -- ^ but height
   scale = 1, -- Scale for all drawn pixels
 }
+
+ACTORS = {}
 
 -- ** Love callbacks **
 
@@ -25,6 +26,8 @@ function love.load()
   love.resize(love.graphics.getDimensions())
 
   PLAYER = Player:new()
+  ACTOR1 = Actor:new()
+  ACTORS = {PLAYER, ACTOR1}
 end
 
 -- Width & height aren't default love variables, but this
@@ -52,10 +55,15 @@ end
 -- World is a grid, currently the size of the window
 function love.draw()
   love.graphics.scale(CONFIG.scale, CONFIG.scale)
+
+  -- Define offset of all graphics, controlling our "Camera"
   -- Not sure why these need to be negative...
   love.graphics.translate(-Camera.offset.x, -Camera.offset.y)
+
   drawGrid()
-  PLAYER:draw()
+  for i, actor in ipairs(ACTORS) do
+    actor:draw()
+  end
 end
 
 function love.update(dt)


### PR DESCRIPTION
This adds a few new features for inheritance and debugging, followed by the addition of the `Actor` class, a generic container for any item in the game that can be collided with. For instance, the `Player` is an `Actor`!

Additionally, some cleanups were done to remove unnecessary `require`'s

Now, to create a new class, you do:

```lua
require "classes/inherit"
NewClass = inherit.from(nil)
-- Remainder of NewClass definitions...
```

And to inherit from this:

```lua
require "classes/inherit"
require "classes/NewClass"
SubClass = inherit.from(NewClass)
-- Any overridden methods...
```

See `Player.lua` for an example of this, including some advanced usage with `super` methods!

Closes #1 